### PR TITLE
Fixed import order using goimports

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/kbinani/screenshot"
 	"image"
 	"image/png"
 	"os"
+
+	"github.com/kbinani/screenshot"
 )
 
 // save *image.RGBA to filePath with PNG format.

--- a/screenshot_linux.go
+++ b/screenshot_linux.go
@@ -1,8 +1,9 @@
 package screenshot
 
 import (
-	"github.com/kbinani/screenshot/internal/xwindow"
 	"image"
+
+	"github.com/kbinani/screenshot/internal/xwindow"
 )
 
 // Capture returns screen capture of specified desktop region.


### PR DESCRIPTION
Probably just prevents future merge conflicts.