### PR TITLE
bugfix(windows): Use real dimensions of a screen to support scaling

### DIFF
--- a/screenshot_windows.go
+++ b/screenshot_windows.go
@@ -13,6 +13,8 @@ var (
 	libUser32, _               = syscall.LoadLibrary("user32.dll")
 	funcGetDesktopWindow, _    = syscall.GetProcAddress(syscall.Handle(libUser32), "GetDesktopWindow")
 	funcEnumDisplayMonitors, _ = syscall.GetProcAddress(syscall.Handle(libUser32), "EnumDisplayMonitors")
+	funcGetMonitorInfo, _      = syscall.GetProcAddress(syscall.Handle(libUser32), "GetMonitorInfoW")
+	funcEnumDisplaySettings, _ = syscall.GetProcAddress(syscall.Handle(libUser32), "EnumDisplaySettingsW")
 )
 
 func Capture(x, y, width, height int) (*image.RGBA, error) {
@@ -140,11 +142,71 @@ type getMonitorBoundsContext struct {
 func getMonitorBoundsCallback(hMonitor win.HMONITOR, hdcMonitor win.HDC, lprcMonitor *win.RECT, dwData uintptr) uintptr {
 	var ctx *getMonitorBoundsContext
 	ctx = (*getMonitorBoundsContext)(unsafe.Pointer(dwData))
-	if ctx.Count == ctx.Index {
-		ctx.Rect = *lprcMonitor
-		return uintptr(0)
-	} else {
+	if ctx.Count != ctx.Index {
 		ctx.Count = ctx.Count + 1
 		return uintptr(1)
+	}
+
+	if realSize := getMonitorRealSize(hMonitor); realSize != nil {
+		ctx.Rect = *realSize
+	} else {
+		ctx.Rect = *lprcMonitor
+	}
+
+	return uintptr(0)
+}
+
+type _MONITORINFOEX struct {
+	win.MONITORINFO
+	DeviceName [win.CCHDEVICENAME]uint16
+}
+
+const _ENUM_CURRENT_SETTINGS = 0xFFFFFFFF
+
+type _DEVMODE struct {
+	_            [68]byte
+	DmSize       uint16
+	_            [6]byte
+	DmPosition   win.POINT
+	_            [86]byte
+	DmPelsWidth  uint32
+	DmPelsHeight uint32
+	_            [40]byte
+}
+
+// getMonitorRealSize makes a call to GetMonitorInfo
+// to obtain the device name for the monitor handle
+// provided to the method.
+//
+// With the device name, EnumDisplaySettings is called to
+// obtain the current configuration for the monitor, this
+// information includes the real resolution of the monitor
+// rather than the scaled version based on DPI.
+//
+// If either handle calls fail, it will return a nil
+// allowing the calling method to use the bounds information
+// returned by EnumDisplayMonitors which may be affected
+// by DPI.
+func getMonitorRealSize(hMonitor win.HMONITOR) *win.RECT {
+	info := _MONITORINFOEX{}
+	info.CbSize = uint32(unsafe.Sizeof(info))
+
+	ret, _, _ := syscall.Syscall(funcGetMonitorInfo, 2, uintptr(hMonitor), uintptr(unsafe.Pointer(&info)), 0)
+	if ret == 0 {
+		return nil
+	}
+
+	devMode := _DEVMODE{}
+	devMode.DmSize = uint16(unsafe.Sizeof(devMode))
+
+	if ret, _, _ := syscall.Syscall(funcEnumDisplaySettings, 3, uintptr(unsafe.Pointer(&info.DeviceName[0])), _ENUM_CURRENT_SETTINGS, uintptr(unsafe.Pointer(&devMode))); ret == 0 {
+		return nil
+	}
+
+	return &win.RECT{
+		Left:   devMode.DmPosition.X,
+		Right:  devMode.DmPosition.X + int32(devMode.DmPelsWidth),
+		Top:    devMode.DmPosition.Y,
+		Bottom: devMode.DmPosition.Y + int32(devMode.DmPelsHeight),
 	}
 }


### PR DESCRIPTION
On windows, when the `EnumDisplayMonitors` function is used with screen
scaling, windows treats the application as DPI unaware leading to the
dimensions returned in the callback parameters not reflecting the actual
resolution of the display.

This leads to a screenshot of the scaled display only containing a
portion of the visible image. To combat this, a new method
`getMonitorRealSize` has been introduced that uses the monitor handle
from the callback parameters to obtain the display adapter name.

With the display adapter name, device configuration can be obtained that
contains the real screen resolution and position, these are then
returned and used as the bounds of the display.