### PR TITLE
A few more fixes

### DIFF
--- a/screenshot.go
+++ b/screenshot.go
@@ -3,8 +3,13 @@
 package screenshot
 
 import (
+	"errors"
 	"image"
 )
+
+// ErrUnsupported is returned when the platform or architecture used to compile the program
+// does not support screenshot, e.g. if you're compiling without CGO on Darwin
+var ErrUnsupported = errors.New("screenshot does not support your platform")
 
 // CaptureDisplay captures whole region of displayIndex'th display, starts at 0 for primary display.
 func CaptureDisplay(displayIndex int) (*image.RGBA, error) {

--- a/screenshot_supported.go
+++ b/screenshot_supported.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !windows && (linux || freebsd || openbsd || netbsd)
+//go:build !s390x && !ppc64le && !darwin && !windows && (linux || freebsd || openbsd || netbsd)
 
 package screenshot
 

--- a/screenshot_unsupported.go
+++ b/screenshot_unsupported.go
@@ -1,13 +1,10 @@
-//go:build !(cgo && darwin) && !windows && !linux && !freebsd && !openbsd && !netbsd
+//go:build s390x || ppc64le || (!(cgo && darwin) && !windows && !linux && !freebsd && !openbsd && !netbsd)
 
 package screenshot
 
 import (
-	"errors"
 	"image"
 )
-
-var ErrUnsupported = errors.New("screenshot does not support your platform")
 
 // Capture returns screen capture of specified desktop region.
 // x and y represent distance from the upper-left corner of primary display.


### PR DESCRIPTION
- Always expose the `ErrUnsupported` error, so that Go programs can compare errors with it.
- It seems gen2gbrain/shm does not support `s390x` and `ppc64le` architecture, so let's add them to the unsupported ones

Also, would you consider:
- enabling issues on this Github repo?
- tagging a release v0.0.1 or something similar? This would make using Go modules easier with this.