### PR TITLE
Fix Incorrect Display Bounds Calculation for Linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kbinani/screenshot
+module github.com/Sohimaster/screenshot
 
 go 1.21
 

--- a/nix.go
+++ b/nix.go
@@ -38,7 +38,6 @@ func NumActiveDisplays() (num int) {
 }
 
 // GetDisplayBounds returns the bounds of displayIndex'th display.
-// The main display is displayIndex = 0.
 func GetDisplayBounds(displayIndex int) (rect image.Rectangle) {
 	defer func() {
 		e := recover()
@@ -67,15 +66,14 @@ func GetDisplayBounds(displayIndex int) (rect image.Rectangle) {
 		return image.Rectangle{}
 	}
 
-	primary := reply.ScreenInfo[0]
-	x0 := int(primary.XOrg)
-	y0 := int(primary.YOrg)
-
+	// Retrieve the screen info for the target display
 	screen := reply.ScreenInfo[displayIndex]
-	x := int(screen.XOrg) - x0
-	y := int(screen.YOrg) - y0
+	x := int(screen.XOrg)
+	y := int(screen.YOrg)
 	w := int(screen.Width)
 	h := int(screen.Height)
+
+	// Use absolute coordinates without offsets
 	rect = image.Rect(x, y, x+w, y+h)
 	return rect
 }


### PR DESCRIPTION
This PR resolves an issue in the GetDisplayBounds function on Linux systems where:

    1. Bounds were incorrectly calculated due to improper handling of absolute coordinates.
    2. Displays with non-standard arrangements produced incorrect bounds.

Changes:

    1. Updated GetDisplayBounds to use absolute coordinates based on xinerama data.

Testing:

    1. Verified the fix using multi-monitor setups on Linux.
    2. Confirmed screenshots correctly match individual monitor bounds.