### PR TITLE
Fix memory address issue in GetDisplayBounds()

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -4,10 +4,11 @@ package screenshot
 
 import (
 	"errors"
-	"github.com/lxn/win"
 	"image"
 	"syscall"
 	"unsafe"
+
+	"github.com/lxn/win"
 )
 
 var (
@@ -102,10 +103,10 @@ func NumActiveDisplays() int {
 }
 
 func GetDisplayBounds(displayIndex int) image.Rectangle {
-	var ctx getMonitorBoundsContext
+	ctx := &getMonitorBoundsContext{}
 	ctx.Index = displayIndex
 	ctx.Count = 0
-	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(unsafe.Pointer(&ctx)))
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(unsafe.Pointer(ctx)))
 	return image.Rect(
 		int(ctx.Rect.Left), int(ctx.Rect.Top),
 		int(ctx.Rect.Right), int(ctx.Rect.Bottom))


### PR DESCRIPTION
Fix issue where the ctx variable was allocated on the stack, causing problems with the enumDisplayMonitors callback function(which is getMonitorBoundsCallback) not updating the object occasionally. Move ctx allocation to the heap by using a pointer to ensure proper memory access during the callback.