### PR TITLE
Pin the argument object before calling enumDisplayMonitors

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"github.com/lxn/win"
 	"image"
+	"runtime"
 	"syscall"
 	"unsafe"
 )
@@ -102,6 +103,10 @@ func NumActiveDisplays() int {
 }
 
 func GetDisplayBounds(displayIndex int) image.Rectangle {
+	return GetDisplayBounds4(displayIndex)
+}
+
+func GetDisplayBounds0(displayIndex int) image.Rectangle {
 	var ctx getMonitorBoundsContext
 	ctx.Index = displayIndex
 	ctx.Count = 0
@@ -109,6 +114,56 @@ func GetDisplayBounds(displayIndex int) image.Rectangle {
 	return image.Rect(
 		int(ctx.Rect.Left), int(ctx.Rect.Top),
 		int(ctx.Rect.Right), int(ctx.Rect.Bottom))
+}
+
+func GetDisplayBounds1(displayIndex int) image.Rectangle {
+	ctx := &getMonitorBoundsContext{}
+	ctx.Index = displayIndex
+	ctx.Count = 0
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(unsafe.Pointer(ctx)))
+	return image.Rect(
+		int(ctx.Rect.Left), int(ctx.Rect.Top),
+		int(ctx.Rect.Right), int(ctx.Rect.Bottom))
+}
+
+func GetDisplayBounds2(displayIndex int) image.Rectangle {
+	ctx := new(getMonitorBoundsContext)
+	ctx.Index = displayIndex
+	ctx.Count = 0
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(unsafe.Pointer(ctx)))
+	runtime.KeepAlive(ctx)
+	return image.Rect(
+		int(ctx.Rect.Left), int(ctx.Rect.Top),
+		int(ctx.Rect.Right), int(ctx.Rect.Bottom))
+}
+
+func GetDisplayBounds3(displayIndex int) image.Rectangle {
+	ctx := new(getMonitorBoundsContext)
+	ctx.Index = displayIndex
+	ctx.Count = 0
+	ptr := unsafe.Pointer(ctx)
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(ptr))
+	runtime.KeepAlive(ptr)
+	return image.Rect(
+		int(ctx.Rect.Left), int(ctx.Rect.Top),
+		int(ctx.Rect.Right), int(ctx.Rect.Bottom))
+}
+
+func GetDisplayBounds4(displayIndex int) image.Rectangle {
+	hmem := win.GlobalAlloc(win.GMEM_MOVEABLE, unsafe.Sizeof(getMonitorBoundsContext{}))
+	defer win.GlobalFree(hmem)
+	ptr := win.GlobalLock(hmem)
+	defer win.GlobalUnlock(hmem)
+
+	(*getMonitorBoundsContext)(ptr).Index = displayIndex
+	(*getMonitorBoundsContext)(ptr).Count = 0
+
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(ptr))
+	rect := ((*getMonitorBoundsContext)(ptr)).Rect
+
+	return image.Rect(
+		int(rect.Left), int(rect.Top),
+		int(rect.Right), int(rect.Bottom))
 }
 
 func getDesktopWindow() win.HWND {

--- a/windows_ge1.21.go
+++ b/windows_ge1.21.go
@@ -1,0 +1,37 @@
+//go:build windows && go1.21
+
+package screenshot
+
+import (
+	"image"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"github.com/lxn/win"
+)
+
+func NumActiveDisplays() int {
+	count := new(int)
+	pinner := new(runtime.Pinner)
+	pinner.Pin(count)
+	defer pinner.Unpin()
+	*count = 0
+	ptr := unsafe.Pointer(count)
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(countupMonitorCallback), uintptr(ptr))
+	return *count
+}
+
+func GetDisplayBounds(displayIndex int) image.Rectangle {
+	ctx := new(getMonitorBoundsContext)
+	pinner := new(runtime.Pinner)
+	pinner.Pin(ctx)
+	defer pinner.Unpin()
+	ctx.Index = displayIndex
+	ctx.Count = 0
+	ptr := unsafe.Pointer(ctx)
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(ptr))
+	return image.Rect(
+		int(ctx.Rect.Left), int(ctx.Rect.Top),
+		int(ctx.Rect.Right), int(ctx.Rect.Bottom))
+}

--- a/windows_lt1.21.go
+++ b/windows_lt1.21.go
@@ -1,0 +1,30 @@
+//go:build windows && !go1.21
+
+package screenshot
+
+import (
+	"image"
+	"syscall"
+	"unsafe"
+
+	"github.com/lxn/win"
+)
+
+func NumActiveDisplays() int {
+	var count int
+	count = 0
+	ptr := unsafe.Pointer(&count)
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(countupMonitorCallback), uintptr(ptr))
+	return count
+}
+
+func GetDisplayBounds(displayIndex int) image.Rectangle {
+	var ctx getMonitorBoundsContext
+	ctx.Index = displayIndex
+	ctx.Count = 0
+	ptr := unsafe.Pointer(&ctx)
+	enumDisplayMonitors(win.HDC(0), nil, syscall.NewCallback(getMonitorBoundsCallback), uintptr(ptr))
+	return image.Rect(
+		int(ctx.Rect.Left), int(ctx.Rect.Top),
+		int(ctx.Rect.Right), int(ctx.Rect.Bottom))
+}


### PR DESCRIPTION
In this PR, we address the issue reported and discussed in #36.
We’ve added logic to ensure the object passed to the callback doesn’t “move” in memory before and after the `enumDisplayMonitors` call.