### PR TITLE
hide the cursor

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -38,6 +38,7 @@ static CGImageRef capture(CGDirectDisplayID id, CGRect diIntersectDisplayLocal, 
             config.sourceRect = diIntersectDisplayLocal;
             config.width = diIntersectDisplayLocal.size.width;
             config.height = diIntersectDisplayLocal.size.height;
+            config.showsCursor = NO;
             [SCScreenshotManager captureImageWithFilter:filter
                                           configuration:config
                                       completionHandler:^(CGImageRef img, NSError* error) {


### PR DESCRIPTION
Add this option in version 14.4+ to hide the cursor, keeping screenshots consistent with older Mac and other platforms.

doc:
https://developer.apple.com/documentation/screencapturekit/scstreamconfiguration